### PR TITLE
Add "&custom list" command

### DIFF
--- a/src/main/java/fr/gravendev/multibot/commands/commands/CustomCommand.java
+++ b/src/main/java/fr/gravendev/multibot/commands/commands/CustomCommand.java
@@ -1,6 +1,7 @@
 package fr.gravendev.multibot.commands.commands;
 
 import fr.gravendev.multibot.commands.ChannelType;
+import fr.gravendev.multibot.commands.commands.customs.ListCommand;
 import fr.gravendev.multibot.commands.commands.customs.RemoveCommand;
 import fr.gravendev.multibot.commands.commands.customs.SetCommand;
 import fr.gravendev.multibot.database.dao.DAOManager;
@@ -18,6 +19,7 @@ public class CustomCommand implements CommandExecutor {
 
     public CustomCommand(DAOManager daoManager) {
         this.argumentsExecutors = Arrays.asList(
+                new ListCommand(daoManager),
                 new SetCommand(daoManager),
                 new RemoveCommand(daoManager)
         );
@@ -72,6 +74,6 @@ public class CustomCommand implements CommandExecutor {
     }
 
     private void help(Message message) {
-        message.getChannel().sendMessage(Utils.errorArguments(getCommand(), "<set,remove> <commande> [valeur]")).queue();
+        message.getChannel().sendMessage(Utils.errorArguments(getCommand(), "<list,set,remove> <commande> [valeur]")).queue();
     }
 }

--- a/src/main/java/fr/gravendev/multibot/commands/commands/customs/ListCommand.java
+++ b/src/main/java/fr/gravendev/multibot/commands/commands/customs/ListCommand.java
@@ -1,0 +1,75 @@
+package fr.gravendev.multibot.commands.commands.customs;
+
+import fr.gravendev.multibot.commands.commands.CommandExecutor;
+import fr.gravendev.multibot.database.dao.CustomCommandDAO;
+import fr.gravendev.multibot.database.dao.DAOManager;
+import fr.gravendev.multibot.database.data.CustomCommandData;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+
+import java.awt.*;
+import java.util.Collection;
+
+public class ListCommand implements CommandExecutor {
+
+    private static final int COMMAND_DESCRIPTION_MAX_LENGTH = 50;
+    
+    private CustomCommandDAO customCommandDAO;
+    
+    public ListCommand(DAOManager daoManager) {
+        this.customCommandDAO = daoManager.getCustomCommandDAO();
+    }
+    
+    @Override
+    public String getCommand() {
+        return "list";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Affiche la liste des commandes customs.";
+    }
+
+    @Override
+    public void execute(Message message, String[] args) {
+        MessageChannel channel = message.getChannel();
+        
+        EmbedBuilder currentEmbedBuilder = new EmbedBuilder();
+        currentEmbedBuilder.setTitle("Custom Commands");
+        currentEmbedBuilder.setColor(Color.MAGENTA);
+        
+        Collection<CustomCommandData> commands = this.customCommandDAO.getAll();
+        
+        if (commands.isEmpty()) {
+            currentEmbedBuilder.setDescription(":no_entry_sign: No custom command available!");
+        }
+        
+        for(CustomCommandData command : commands) {
+            String commandText = this.buildCommandText(command);
+            
+            try {
+                currentEmbedBuilder.appendDescription(commandText);
+            } catch(IllegalArgumentException e) {
+                channel.sendMessage(currentEmbedBuilder.build()).queue();
+
+                currentEmbedBuilder.setDescription(commandText);
+                currentEmbedBuilder.setColor(Color.MAGENTA);
+            }
+        }
+        
+        channel.sendMessage(currentEmbedBuilder.build()).queue();
+    }
+    
+    private String buildCommandText(CustomCommandData command) {
+        String clippedText = command.getText();
+
+        if (clippedText.length() >= COMMAND_DESCRIPTION_MAX_LENGTH) {
+            clippedText = clippedText.substring(0, COMMAND_DESCRIPTION_MAX_LENGTH).trim() + "...";
+        }
+
+        return ":label: **`" + command.getCommand() + "`**\n" + 
+                clippedText + "\n\n";
+    }
+    
+}

--- a/src/main/java/fr/gravendev/multibot/commands/commands/customs/ListCommand.java
+++ b/src/main/java/fr/gravendev/multibot/commands/commands/customs/ListCommand.java
@@ -36,13 +36,13 @@ public class ListCommand implements CommandExecutor {
         MessageChannel channel = message.getChannel();
         
         EmbedBuilder currentEmbedBuilder = new EmbedBuilder();
-        currentEmbedBuilder.setTitle("Custom Commands");
+        currentEmbedBuilder.setTitle("Commandes Customs");
         currentEmbedBuilder.setColor(Color.MAGENTA);
         
         Collection<CustomCommandData> commands = this.customCommandDAO.getAll();
         
         if (commands.isEmpty()) {
-            currentEmbedBuilder.setDescription(":no_entry_sign: No custom command available!");
+            currentEmbedBuilder.setDescription(":no_entry_sign: Aucune commande custom disponible !");
         }
         
         for(CustomCommandData command : commands) {

--- a/src/main/java/fr/gravendev/multibot/database/dao/CustomCommandDAO.java
+++ b/src/main/java/fr/gravendev/multibot/database/dao/CustomCommandDAO.java
@@ -7,6 +7,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CustomCommandDAO extends DAO<CustomCommandData> {
     public CustomCommandDAO(DatabaseConnection databaseConnection) {
@@ -39,6 +41,31 @@ public class CustomCommandDAO extends DAO<CustomCommandData> {
             return new CustomCommandData(command, text);
         }
         return null;
+    }
+    
+    public List<CustomCommandData> getAll(Connection connection) throws SQLException {
+        PreparedStatement preparedStatement = connection.prepareStatement("SELECT * FROM custom_commands");
+        ResultSet resultSet = preparedStatement.executeQuery();
+        
+        List<CustomCommandData> commands = new ArrayList<>();
+        
+        while (resultSet.next()) {
+            String command = resultSet.getString("command");
+            String text = resultSet.getString("text");
+            
+            CustomCommandData commandData = new CustomCommandData(command, text);
+            commands.add(commandData);
+        }
+        
+        return commands;
+    }
+    public List<CustomCommandData> getAll() {
+        try (Connection connection = this.getConnection()) {
+            return this.getAll(connection);
+        } catch (SQLException exception) {
+            exception.printStackTrace();
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
This adds the "**&custom list**" command, in order to be able to list the custom commands.

![image](https://user-images.githubusercontent.com/13206601/70869932-18cb1180-1f8e-11ea-8a53-7600b356e14d.png)

### Handled cases
* When a command description is too long, it gets clipped to a maximum of 50 characters
* When there are too many commands and the description gets too long, multiple embeds are sent correctly
* Where there is no command, an error message is sent

![image](https://user-images.githubusercontent.com/13206601/70869937-2e403b80-1f8e-11ea-8223-01d3dc9c1df0.png)
