### PR TITLE
Prevents from putting the same emote twice in poll

### DIFF
--- a/src/main/java/fr/gravendev/multibot/polls/Poll.java
+++ b/src/main/java/fr/gravendev/multibot/polls/Poll.java
@@ -1,18 +1,26 @@
 package fr.gravendev.multibot.polls;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Emote;
+import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
 
 import java.awt.*;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
 class Poll {
-    private static final String[] EMOTES = {"1\u20E3", "2\u20E3", "3\u20E3", "4\u20E3", "5\u20E3", "6\u20E3", "7\u20E3", "8\u20E3", "9\u20E3"};
+    private static final String[] EMOTES = {
+            "1\ufe0f\u20e3", "2\ufe0f\u20e3", "3\ufe0f\u20e3",
+            "4\ufe0f\u20e3", "5\ufe0f\u20e3", "6\ufe0f\u20e3",
+            "7\ufe0f\u20e3", "8\ufe0f\u20e3", "9\ufe0f\u20e3"
+    };
 
     private final User user;
     private final long messageId;
@@ -48,23 +56,54 @@ class Poll {
         }
         update();
     }
+    
+    boolean hasEmote(String emote) {
+        return this.emotes.containsValue(emote);
+    }
 
     void setEmote(int numberEmote, String emote) {
         if (this.choices.containsKey(numberEmote)) {
+            // Find any choice with the same emote and
+            // swap its emote with this choice
+            this.emotes.entrySet().stream()
+                    .filter(entry -> entry.getValue().equals(emote))
+                    .findAny()
+                    .ifPresent(entry -> {
+                        String newEmote = this.emotes.get(numberEmote);
+                        entry.setValue(newEmote);
+                    });
+            
             this.emotes.put(numberEmote, emote);
         }
+
         update();
     }
 
+    private void removeWrongReactions(List<MessageReaction> reactions) {
+        boolean removeNexts = false;
+        
+        for (int i = 0; i < reactions.size(); i++) {
+            MessageReaction reaction = reactions.get(i);
+
+            if (!reaction.isSelf()) {
+                continue;
+            }
+
+            String emote = reaction.getReactionEmote().getName();
+            
+            if (removeNexts || !emote.equals(this.emotes.get(i + 1))) {
+                reaction.removeReaction().queue();
+                removeNexts = true;
+            }
+        }
+    }
+    
     private void update() {
         this.user.openPrivateChannel().queue(privateChannel ->
                 privateChannel.retrieveMessageById(this.messageId).queue(message -> {
-                    User selfUser = message.getJDA().getSelfUser();
-                    message.getReactions().forEach(messageReaction -> {
-                        if (!this.emotes.containsValue(messageReaction.getReactionEmote().getName())) {
-                            messageReaction.removeReaction(selfUser).queue();
-                        }
-                    });
+                    List<MessageReaction> reactions = message.getReactions();
+                    removeWrongReactions(reactions);
+                    
                     message.editMessage(buildMessage().build()).queue(message1 -> this.emotes.values()
                             .stream()
                             .filter(emote -> !emote.equalsIgnoreCase(" "))

--- a/src/main/java/fr/gravendev/multibot/polls/Poll.java
+++ b/src/main/java/fr/gravendev/multibot/polls/Poll.java
@@ -1,9 +1,7 @@
 package fr.gravendev.multibot.polls;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.MessageBuilder;
-import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;


### PR DESCRIPTION
This prevents the user from putting the same emote twice in poll by swapping the old emote with the choice which already has the emote we're trying to set.

For example, if you have:
![image](https://user-images.githubusercontent.com/13206601/71728310-0a5d7080-2e3d-11ea-87a7-b541bf637689.png)

And you want to put a carrot on the choice "The Answer D", the choices "Carrot" and "The Answer D" will swap emotes:
![image](https://user-images.githubusercontent.com/13206601/71728361-2cef8980-2e3d-11ea-9d00-a192acdc17b2.png)

*I could have displayed an error message instead of doing this, but this would have made swapping emotes hard.*