### PR TITLE
Add new utility to make user searching easier #19

### DIFF
--- a/src/main/java/fr/gravendev/multibot/commands/commands/UserinfoCommand.java
+++ b/src/main/java/fr/gravendev/multibot/commands/commands/UserinfoCommand.java
@@ -1,6 +1,7 @@
 package fr.gravendev.multibot.commands.commands;
 
 import fr.gravendev.multibot.commands.ChannelType;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import fr.gravendev.multibot.utils.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
@@ -8,6 +9,7 @@ import net.dv8tion.jda.api.entities.*;
 import java.awt.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class UserinfoCommand implements CommandExecutor {
@@ -35,10 +37,21 @@ public class UserinfoCommand implements CommandExecutor {
     @Override
     public void execute(Message message, String[] args) {
         Member member = message.getMember();
-        List<Member> mentionedMembers = message.getMentionedMembers();
 
-        if (mentionedMembers.size() > 0) {
-            member = mentionedMembers.get(0);
+        if (args.length > 0) {
+            Optional<Member> opMember = UserSearchUtils.searchMember(
+                    message.getGuild(),
+                    args[0],
+                    UserSearchUtils.SearchMode.SENSITIVE
+            );
+            
+            if (opMember.isPresent()) {
+                member = opMember.get();
+            } 
+            else {
+                UserSearchUtils.sendUserNotFound(message.getChannel());
+                return;
+            }
         }
 
         User user = member.getUser();

--- a/src/main/java/fr/gravendev/multibot/moderation/AModeration.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/AModeration.java
@@ -45,7 +45,8 @@ public abstract class AModeration implements CommandExecutor {
 
         Guild guild = message.getGuild();
         
-        Optional<Member> opMember = UserSearchUtils.searchMember(guild, args[0]);
+        Optional<Member> opMember =
+                UserSearchUtils.searchMember(guild, args[0], UserSearchUtils.SearchMode.SAFE);
         
         if (!opMember.isPresent()) {
             UserSearchUtils.sendUserNotFound(messageChannel);

--- a/src/main/java/fr/gravendev/multibot/moderation/AModeration.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/AModeration.java
@@ -4,14 +4,17 @@ import fr.gravendev.multibot.commands.commands.CommandCategory;
 import fr.gravendev.multibot.commands.commands.CommandExecutor;
 import fr.gravendev.multibot.database.dao.DAOManager;
 import fr.gravendev.multibot.database.dao.InfractionDAO;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import fr.gravendev.multibot.utils.Utils;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 
+import javax.swing.text.html.Option;
 import java.awt.*;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -33,16 +36,23 @@ public abstract class AModeration implements CommandExecutor {
     // TODO Refactor it : split it into differents methods, etc.
     @Override
     public void execute(Message message, String[] args) {
-        List<Member> mentionedMembers = message.getMentionedMembers();
         MessageChannel messageChannel = message.getChannel();
 
-        if (mentionedMembers.size() == 0) {
+        if (args.length == 0) {
             messageChannel.sendMessage(Utils.errorArguments(getCommand(), "@membre "+ (isTemporary() ? "<durée> " : "") + "<raison>")).queue();
             return;
         }
 
         Guild guild = message.getGuild();
-        Member member = mentionedMembers.get(0);
+        
+        Optional<Member> opMember = UserSearchUtils.searchMember(guild, args[0]);
+        
+        if (!opMember.isPresent()) {
+            UserSearchUtils.sendUserNotFound(messageChannel);
+            return;
+        }
+        
+        Member member = opMember.get();
         User victim = member.getUser();
 
         String reason = "Non définie";

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/AntiCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/AntiCommand.java
@@ -75,7 +75,7 @@ public class AntiCommand implements CommandExecutor {
         }
 
         if (GuildUtils.hasRole(mentionedMembers.get(0), "anti-" + args[0])) {
-            message.getChannel().sendMessage("Ce membre possède déjà le rôle anti-" + args[1]).queue();
+            message.getChannel().sendMessage("Ce membre possède déjà le rôle anti-" + args[0]).queue();
             return;
         }
 

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/AntiCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/AntiCommand.java
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -100,7 +101,7 @@ public class AntiCommand implements CommandExecutor {
             message.getChannel().sendMessage("Le rôle anti-" + args[0] + " a bien été attribué.").queue();
 
             String reason = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
-            warn(message, reason);
+            warn(targetMember, message.getChannel(), reason);
 
             TextChannel logsTextChannel = guild.getTextChannelById(Configuration.LOGS.getValue());
             if (logsTextChannel == null) {
@@ -129,9 +130,8 @@ public class AntiCommand implements CommandExecutor {
         antiRolesDAO.save(antiRoleData);
     }
 
-    private void warn(Message message, String reason) {
-        Member member = message.getMentionedMembers().get(0);
-        Guild guild = message.getGuild();
+    private void warn(Member member, MessageChannel channel, String reason) {
+        Guild guild = member.getGuild();
 
         InfractionData data = new InfractionData(member.getId(), member.getId(), InfractionType.WARN, reason, new java.util.Date(), null);
 
@@ -141,7 +141,7 @@ public class AntiCommand implements CommandExecutor {
         EmbedBuilder embedBuilder = new EmbedBuilder().setColor(Color.RED)
                 .setAuthor("[WARN] " + member.getUser().getAsTag(), member.getUser().getAvatarUrl())
                 .addField("Utilisateur:", member.getAsMention(), true)
-                .addField("Modérateur:", message.getJDA().getSelfUser().getAsMention(), true)
+                .addField("Modérateur:", guild.getJDA().getSelfUser().getAsMention(), true)
                 .addField("Raison:", reason, true);
 
         TextChannel logsChannel = guild.getTextChannelById(logs);
@@ -149,7 +149,7 @@ public class AntiCommand implements CommandExecutor {
             logsChannel.sendMessage(embedBuilder.build()).queue();
         }
 
-        message.getChannel().sendMessage(Utils.getWarnEmbed(member.getUser(), reason)).queue();
+        channel.sendMessage(Utils.getWarnEmbed(member.getUser(), reason)).queue();
     }
 
 }

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/AntiCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/AntiCommand.java
@@ -10,13 +10,14 @@ import fr.gravendev.multibot.database.data.AntiRoleData;
 import fr.gravendev.multibot.database.data.InfractionData;
 import fr.gravendev.multibot.moderation.InfractionType;
 import fr.gravendev.multibot.utils.Configuration;
-import fr.gravendev.multibot.utils.GuildUtils;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import fr.gravendev.multibot.utils.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
@@ -26,8 +27,8 @@ import java.sql.Date;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class AntiCommand implements CommandExecutor {
 
@@ -46,7 +47,7 @@ public class AntiCommand implements CommandExecutor {
 
     @Override
     public String getDescription() {
-        return "Permet de mettre un role anti- (meme, repost...) à une personne pour une durée de 6 mois.";
+        return "Permet de mettre un rôle anti- (meme, repost...) à une personne pour une durée de 6 mois.";
     }
 
     @Override
@@ -66,48 +67,53 @@ public class AntiCommand implements CommandExecutor {
 
     @Override
     public void execute(Message message, String[] args) {
-
-        List<Member> mentionedMembers = message.getMentionedMembers();
-
-        if (args.length < 3 || mentionedMembers.size() == 0 || !"repost review meme".contains(args[0])) {
-            message.getChannel().sendMessage(Utils.errorArguments(getCommand(), "<repost,review,meme> @membre <raison>")).queue();
+        if (args.length < 3 || !"repost review meme".contains(args[0])) {
+            MessageEmbed embed = Utils.errorArguments(getCommand(), "<repost,review,meme> @membre <raison>");
+            message.getChannel().sendMessage(embed).queue();
             return;
         }
 
-        if (GuildUtils.hasRole(mentionedMembers.get(0), "anti-" + args[0])) {
-            message.getChannel().sendMessage("Ce membre possède déjà le rôle anti-" + args[0]).queue();
-            return;
-        }
-
-        Member member = mentionedMembers.get(0);
         Guild guild = message.getGuild();
+        Optional<Member> opMember = UserSearchUtils.searchMember(guild, args[1]);
+
+        if (!opMember.isPresent()) {
+            UserSearchUtils.sendUserNotFound(message.getChannel());
+            return;
+        }
+
+        Member targetMember = opMember.get();
+
         Role role = guild.getRoleById(Configuration.getConfigByName("anti_" + args[0]).getValue());
         if (role == null) {
             return;
         }
 
-        guild.addRoleToMember(member, role).queue(unused -> {
+        if (targetMember.getRoles().contains(role)) {
+            message.getChannel().sendMessage("Ce membre possède déjà le rôle anti-" + args[0]).queue();
+            return;
+        }
 
-            saveInDatabase(args[0], member);
+        guild.addRoleToMember(targetMember, role).queue(unused -> {
+
+            saveInDatabase(args[0], targetMember);
+
+            message.getChannel().sendMessage("Le rôle anti-" + args[0] + " a bien été attribué.").queue();
+
+            String reason = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
+            warn(message, reason);
 
             TextChannel logsTextChannel = guild.getTextChannelById(Configuration.LOGS.getValue());
             if (logsTextChannel == null) {
                 return;
             }
 
-            message.getChannel().sendMessage("Le rôle anti-" + args[0] + " a bien été attribué.").queue();
-
             logsTextChannel.sendMessage(new EmbedBuilder()
                     .setColor(Color.ORANGE)
-                    .setTitle("[ANTI-" + args[0].toUpperCase() + "] " + member.getUser().getAsTag())
-                    .addField("Utilisateur :", member.getAsMention(), true)
+                    .setTitle("[ANTI-" + args[0].toUpperCase() + "] " + targetMember.getUser().getAsTag())
+                    .addField("Utilisateur :", targetMember.getAsMention(), true)
                     .addField("Modérateur :", message.getAuthor().getAsMention(), true)
                     .addField("Fin :", Utils.getDateFormat().format(Date.from(Instant.now().plus(31, ChronoUnit.DAYS))), true)
                     .build()).queue();
-
-            String reason = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
-            warn(message, reason);
-
         });
 
     }

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/BanInfoCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/BanInfoCommand.java
@@ -7,6 +7,7 @@ import fr.gravendev.multibot.database.dao.DAOManager;
 import fr.gravendev.multibot.database.dao.InfractionDAO;
 import fr.gravendev.multibot.database.data.InfractionData;
 import fr.gravendev.multibot.moderation.InfractionType;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import fr.gravendev.multibot.utils.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
@@ -15,16 +16,15 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
 
 import java.awt.*;
 import java.sql.SQLException;
 import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Optional;
 
 public class BanInfoCommand implements CommandExecutor {
 
-    private static final Pattern mentionUserPattern = Pattern.compile("<@!?([0-9]{8,})>");
     private final InfractionDAO infractionDAO;
 
     public BanInfoCommand(DAOManager daoManager) {
@@ -53,49 +53,53 @@ public class BanInfoCommand implements CommandExecutor {
 
     @Override
     public void execute(Message message, String[] args) {
-        if (args.length == 0 || extractId(args[0]) == null) {
+        if (args.length == 0) {
             message.getChannel().sendMessage(Utils.errorArguments(getCommand(), "@utilisateur")).queue();
             return;
         }
 
-        String id = extractId(args[0]);
+        Optional<User> opUser = UserSearchUtils.searchUser(message.getJDA(), args[0]);
+        
+        if (!opUser.isPresent()) {
+            UserSearchUtils.sendUserNotFound(message.getChannel());
+            return;
+        }
+        
+        User user = opUser.get();
+        Guild guild = message.getGuild();
 
-        message.getJDA().retrieveUserById(id).queue(user -> {
-            Guild guild = message.getGuild();
+        guild.retrieveBanList().queue(banList -> {
 
-            guild.retrieveBanList().queue((banList) -> {
+            MessageEmbed embed;
 
-                MessageEmbed embed;
+            if (banList.stream().anyMatch(ban -> ban.getUser().getId().equals(user.getId()))) {
 
-                if (banList.stream().anyMatch(ban -> ban.getUser().getId().equals(user.getId()))) {
+                InfractionData data;
+                try {
+                    data = infractionDAO.getLast(user.getId(), InfractionType.BAN);
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                    return;
+                }
 
-                    InfractionData data;
-                    try {
-                        data = infractionDAO.getLast(id, InfractionType.BAN);
-                    } catch (SQLException e) {
-                        e.printStackTrace();
-                        return;
-                    }
+                if (data != null) {
 
-                    if (data != null) {
+                    Date dateEnd = data.getEnd();
+                    String end = dateEnd == null ? "Jamais" : Utils.getDateFormat().format(dateEnd);
 
-                        Date dateEnd = data.getEnd();
-                        String end = dateEnd == null ? "Jamais" : Utils.getDateFormat().format(dateEnd);
+                    embed = new EmbedBuilder().setColor(Color.RED)
+                            .setTitle("Informations de ban " + user.getName())
+                            .addField("Raison:", data.getReason(), false)
+                            .addField("Date de fin:", end, false)
+                            .addField("Par:", "<@" + data.getPunisherId() + ">", false)
+                            .addField("Le:", Utils.getDateFormat().format(data.getStart()), false).build();
 
-                        embed = new EmbedBuilder().setColor(Color.RED)
-                                .setTitle("Informations de ban " + user.getName())
-                                .addField("Raison:", data.getReason(), false)
-                                .addField("Date de fin:", end, false)
-                                .addField("Par:", "<@" + data.getPunisherId() + ">", false)
-                                .addField("Le:", Utils.getDateFormat().format(data.getStart()), false).build();
-
-                    } else
-                        embed = Utils.buildEmbed(Color.RED, "Impossible de trouver les informations de bannissement");
                 } else
-                    embed = Utils.buildEmbed(Color.RED, "Cet utilisateur n'est pas bannis !");
+                    embed = Utils.buildEmbed(Color.RED, "Impossible de trouver les informations de bannissement");
+            } else
+                embed = Utils.buildEmbed(Color.RED, "Cet utilisateur n'est pas banni !");
 
-                message.getChannel().sendMessage(embed).queue();
-            });
+            message.getChannel().sendMessage(embed).queue();
         });
     }
 
@@ -107,14 +111,6 @@ public class BanInfoCommand implements CommandExecutor {
     @Override
     public boolean isAuthorizedChannel(MessageChannel channel) {
         return true;
-    }
-
-    private static String extractId(String id) {
-        Matcher matcher = mentionUserPattern.matcher(id);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-        return null;
     }
 
 }

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/InfractionsCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/InfractionsCommand.java
@@ -59,7 +59,11 @@ public class InfractionsCommand implements CommandExecutor {
             }
             
             Guild guild = message.getGuild();
-            Optional<Member> opMember = UserSearchUtils.searchMember(guild, args[0]);
+            Optional<Member> opMember = UserSearchUtils.searchMember(
+                    guild,
+                    args[0],
+                    UserSearchUtils.SearchMode.SENSITIVE
+            );
             
             if (!opMember.isPresent()) {
                 UserSearchUtils.sendUserNotFound(message.getChannel());

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/MuteInfoCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/MuteInfoCommand.java
@@ -59,7 +59,8 @@ public class MuteInfoCommand implements CommandExecutor {
         }
         
         Guild guild = message.getGuild();
-        Optional<Member> opMember = UserSearchUtils.searchMember(guild, args[0]);
+        Optional<Member> opMember =
+                UserSearchUtils.searchMember(guild, args[0], UserSearchUtils.SearchMode.SENSITIVE);
 
         if (!opMember.isPresent()) {
             UserSearchUtils.sendUserNotFound(message.getChannel());

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/MuteInfoCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/MuteInfoCommand.java
@@ -7,9 +7,11 @@ import fr.gravendev.multibot.database.dao.InfractionDAO;
 import fr.gravendev.multibot.database.data.InfractionData;
 import fr.gravendev.multibot.moderation.InfractionType;
 import fr.gravendev.multibot.utils.GuildUtils;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import fr.gravendev.multibot.utils.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
@@ -17,7 +19,7 @@ import net.dv8tion.jda.api.entities.MessageChannel;
 import java.awt.*;
 import java.sql.SQLException;
 import java.util.Date;
-import java.util.List;
+import java.util.Optional;
 
 public class MuteInfoCommand implements CommandExecutor {
 
@@ -49,14 +51,23 @@ public class MuteInfoCommand implements CommandExecutor {
 
     @Override
     public void execute(Message message, String[] args) {
-        List<Member> mentionedMembers = message.getMentionedMembers();
         MessageChannel messageChannel = message.getChannel();
-        if (mentionedMembers.size() == 0) {
+
+        if (args.length == 0) {
             messageChannel.sendMessage(Utils.buildEmbed(Color.RED, "Utilisation: muteinfo @member")).queue();
             return;
         }
+        
+        Guild guild = message.getGuild();
+        Optional<Member> opMember = UserSearchUtils.searchMember(guild, args[0]);
 
-        Member member = mentionedMembers.get(0);
+        if (!opMember.isPresent()) {
+            UserSearchUtils.sendUserNotFound(message.getChannel());
+            return;
+        }
+
+        Member member = opMember.get();
+        
         if (!GuildUtils.hasRole(member, "Muted")) {
             messageChannel.sendMessage(Utils.buildEmbed(Color.RED, "Ce membre n'est pas mute")).queue();
             return;

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/UnbanCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/UnbanCommand.java
@@ -55,11 +55,12 @@ public class UnbanCommand implements CommandExecutor {
             return;
         }
 
+        // TODO: Replace this by UserSearchUtils, when it is possible to get the user id without retrieving it.
         String id = extractId(args[0]);
 
         message.getGuild().retrieveBanList().queue((banList) -> {
             if (banList.stream().noneMatch(ban -> ban.getUser().getId().equals(id))) {
-                message.getChannel().sendMessage(Utils.buildEmbed(Color.RED, "Cet utilisateur n'est pas bannis")).queue();
+                message.getChannel().sendMessage(Utils.buildEmbed(Color.RED, "Cet utilisateur n'est pas banni !")).queue();
                 return;
             }
 

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/UnbanCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/UnbanCommand.java
@@ -6,8 +6,10 @@ import fr.gravendev.multibot.database.dao.DAOManager;
 import fr.gravendev.multibot.database.dao.InfractionDAO;
 import fr.gravendev.multibot.database.data.InfractionData;
 import fr.gravendev.multibot.moderation.InfractionType;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import fr.gravendev.multibot.utils.Utils;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
@@ -15,12 +17,11 @@ import net.dv8tion.jda.api.entities.User;
 import java.awt.*;
 import java.sql.SQLException;
 import java.util.Date;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 public class UnbanCommand implements CommandExecutor {
 
-    private static final Pattern mentionUserPattern = Pattern.compile("<@!?([0-9]{8,})>");
     private final InfractionDAO infractionDAO;
 
     public UnbanCommand(DAOManager daoManager) {
@@ -49,24 +50,35 @@ public class UnbanCommand implements CommandExecutor {
 
     @Override
     public void execute(Message message, String[] args) {
-
-        if (args.length == 0 || extractId(args[0]) == null) {
+        if (args.length == 0) {
             message.getChannel().sendMessage(Utils.errorArguments(getCommand(), "@utilisateur")).queue();
             return;
         }
 
-        // TODO: Replace this by UserSearchUtils, when it is possible to get the user id without retrieving it.
-        String id = extractId(args[0]);
+        OptionalLong opUserId = UserSearchUtils.searchId(args[0]);
 
-        message.getGuild().retrieveBanList().queue((banList) -> {
-            if (banList.stream().noneMatch(ban -> ban.getUser().getId().equals(id))) {
+        if (!opUserId.isPresent()) {
+            UserSearchUtils.sendUserNotFound(message.getChannel());
+            return;
+        }
+
+        long id = opUserId.getAsLong();
+
+        message.getGuild().retrieveBanList().queue(banList -> {
+            Optional<Guild.Ban> opBan = banList.stream()
+                    .filter(ban -> ban.getUser().getIdLong() == id)
+                    .findAny();
+
+            if (!opBan.isPresent()) {
                 message.getChannel().sendMessage(Utils.buildEmbed(Color.RED, "Cet utilisateur n'est pas banni !")).queue();
                 return;
             }
 
+            User user = opBan.get().getUser();
+            
             InfractionData data;
             try {
-                data = infractionDAO.getLast(id, InfractionType.BAN);
+                data = infractionDAO.getLast(user.getId(), InfractionType.BAN);
             } catch (SQLException e) {
                 e.printStackTrace();
                 return;
@@ -78,26 +90,11 @@ public class UnbanCommand implements CommandExecutor {
                 infractionDAO.save(data);
             }
 
-            message.getGuild().unban(id).queue();
-
-            User user = message.getJDA().getUserCache().getElementById(id);
-
-            message.getChannel().sendMessage(Utils.buildEmbed(Color.DARK_GRAY, (user != null ? user.getName() : id) + " vient d'être unban")).queue();
-
-            if(user == null) {
-                return;
-            }
+            message.getGuild().unban(user).queue();
+            message.getChannel().sendMessage(Utils.buildEmbed(Color.DARK_GRAY, user.getName() + " vient d'être unban")).queue();
 
             user.openPrivateChannel().queue(privateChannel ->  privateChannel.sendMessage("Vous avez été débanni du discord GravenCommunity !").queue());
         });
-    }
-
-    private static String extractId(String id) {
-        Matcher matcher = mentionUserPattern.matcher(id);
-        if (matcher.find()) {
-            return matcher.group(1);
-        }
-        return null;
     }
 
 }

--- a/src/main/java/fr/gravendev/multibot/moderation/commands/UnmuteCommand.java
+++ b/src/main/java/fr/gravendev/multibot/moderation/commands/UnmuteCommand.java
@@ -8,6 +8,7 @@ import fr.gravendev.multibot.database.data.InfractionData;
 import fr.gravendev.multibot.moderation.InfractionType;
 import fr.gravendev.multibot.utils.Configuration;
 import fr.gravendev.multibot.utils.GuildUtils;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import fr.gravendev.multibot.utils.Utils;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
@@ -19,7 +20,7 @@ import net.dv8tion.jda.api.entities.Role;
 import java.awt.*;
 import java.sql.SQLException;
 import java.util.Date;
-import java.util.List;
+import java.util.Optional;
 
 public class UnmuteCommand implements CommandExecutor {
 
@@ -51,16 +52,23 @@ public class UnmuteCommand implements CommandExecutor {
 
     @Override
     public void execute(Message message, String[] args) {
-        List<Member> mentionedMembers = message.getMentionedMembers();
         MessageChannel messageChannel = message.getChannel();
         Guild guild = message.getGuild();
 
-        if (mentionedMembers.size() == 0) {
+        if (args.length == 0) {
             message.getChannel().sendMessage(Utils.errorArguments(getCommand(), "@membre")).queue();
             return;
         }
+        
+        Optional<Member> opMember = UserSearchUtils.searchMember(guild, args[0]);
 
-        Member member = mentionedMembers.get(0);
+        if (!opMember.isPresent()) {
+            UserSearchUtils.sendUserNotFound(message.getChannel());
+            return;
+        }
+
+        Member member = opMember.get();
+        
         if (!GuildUtils.hasRole(member, "Muted")) {
             messageChannel.sendMessage(Utils.buildEmbed(Color.RED, "Ce membre n'est pas mute")).queue();
             return;

--- a/src/main/java/fr/gravendev/multibot/polls/Poll.java
+++ b/src/main/java/fr/gravendev/multibot/polls/Poll.java
@@ -1,18 +1,26 @@
 package fr.gravendev.multibot.polls;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Emote;
+import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
 
 import java.awt.*;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
 class Poll {
-    private static final String[] EMOTES = {"1\u20E3", "2\u20E3", "3\u20E3", "4\u20E3", "5\u20E3", "6\u20E3", "7\u20E3", "8\u20E3", "9\u20E3"};
+    private static final String[] EMOTES = {
+            "1\ufe0f\u20e3", "2\ufe0f\u20e3", "3\ufe0f\u20e3",
+            "4\ufe0f\u20e3", "5\ufe0f\u20e3", "6\ufe0f\u20e3",
+            "7\ufe0f\u20e3", "8\ufe0f\u20e3", "9\ufe0f\u20e3"
+    };
 
     private final User user;
     private final long messageId;
@@ -48,23 +56,54 @@ class Poll {
         }
         update();
     }
+    
+    boolean hasEmote(String emote) {
+        return this.emotes.containsValue(emote);
+    }
 
     void setEmote(int numberEmote, String emote) {
         if (this.choices.containsKey(numberEmote)) {
+            // Find any choice with the same emote and
+            // swap its emote with this choice
+            this.emotes.entrySet().stream()
+                    .filter(entry -> entry.getValue().equals(emote))
+                    .findAny()
+                    .ifPresent(entry -> {
+                        String newEmote = this.emotes.get(numberEmote);
+                        entry.setValue(newEmote);
+                    });
+            
             this.emotes.put(numberEmote, emote);
         }
+
         update();
     }
 
+    private void removeWrongReactions(List<MessageReaction> reactions) {
+        boolean removeNexts = false;
+        
+        for (int i = 0; i < reactions.size(); i++) {
+            MessageReaction reaction = reactions.get(i);
+
+            if (!reaction.isSelf()) {
+                continue;
+            }
+
+            String emote = reaction.getReactionEmote().getName();
+            
+            if (removeNexts || !emote.equals(this.emotes.get(i + 1))) {
+                reaction.removeReaction().queue();
+                removeNexts = true;
+            }
+        }
+    }
+    
     private void update() {
         this.user.openPrivateChannel().queue(privateChannel ->
                 privateChannel.retrieveMessageById(this.messageId).queue(message -> {
-                    User selfUser = message.getJDA().getSelfUser();
-                    message.getReactions().forEach(messageReaction -> {
-                        if (!this.emotes.containsValue(messageReaction.getReactionEmote().getName())) {
-                            messageReaction.removeReaction(selfUser).queue();
-                        }
-                    });
+                    List<MessageReaction> reactions = message.getReactions();
+                    removeWrongReactions(reactions);
+                    
                     message.editMessage(buildMessage().build()).queue(message1 -> this.emotes.values()
                             .stream()
                             .filter(emote -> !emote.equalsIgnoreCase(" "))

--- a/src/main/java/fr/gravendev/multibot/polls/Poll.java
+++ b/src/main/java/fr/gravendev/multibot/polls/Poll.java
@@ -1,9 +1,7 @@
 package fr.gravendev.multibot.polls;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.MessageBuilder;
-import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;

--- a/src/main/java/fr/gravendev/multibot/rank/RankCommand.java
+++ b/src/main/java/fr/gravendev/multibot/rank/RankCommand.java
@@ -6,6 +6,7 @@ import fr.gravendev.multibot.commands.commands.CommandExecutor;
 import fr.gravendev.multibot.database.dao.DAOManager;
 import fr.gravendev.multibot.database.dao.ExperienceDAO;
 import fr.gravendev.multibot.database.data.ExperienceData;
+import fr.gravendev.multibot.utils.UserSearchUtils;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
@@ -52,9 +53,23 @@ public class RankCommand implements CommandExecutor {
     public void execute(Message message, String[] args) {
         try {
             Member member = message.getMember();
-            List<Member> mentionedMembers = message.getMentionedMembers();
-            if (mentionedMembers.size() > 0)
-                member = mentionedMembers.get(0);
+
+            if (args.length > 0) {
+                Optional<Member> opMember = UserSearchUtils.searchMember(
+                        message.getGuild(),
+                        args[0],
+                        UserSearchUtils.SearchMode.SENSITIVE
+                );
+
+                if (opMember.isPresent()) {
+                    member = opMember.get();
+                }
+                else {
+                    UserSearchUtils.sendUserNotFound(message.getChannel());
+                    return;
+                }
+            }
+            
             User user = member.getUser();
 
             if (user.isBot()) return;

--- a/src/main/java/fr/gravendev/multibot/utils/GuildUtils.java
+++ b/src/main/java/fr/gravendev/multibot/utils/GuildUtils.java
@@ -12,7 +12,7 @@ public class GuildUtils {
 
     public static boolean hasRole(Member member, String roleName) {
         Guild guild = member.getGuild();
-        List<Role> memberRoles = guild.getRolesByName(roleName, false);
+        List<Role> memberRoles = guild.getRolesByName(roleName, true);
         return memberRoles.stream()
                 .findAny()
                 .map(role -> guild.getMembersWithRoles(role).contains(member))

--- a/src/main/java/fr/gravendev/multibot/utils/UserSearchUtils.java
+++ b/src/main/java/fr/gravendev/multibot/utils/UserSearchUtils.java
@@ -1,0 +1,250 @@
+package fr.gravendev.multibot.utils;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+
+import java.awt.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class UserSearchUtils {
+
+    public enum SearchMode {
+        /**
+         * Tries to search from all the possible ways (mention, id, tag, full username and partial username)
+         * with a non-negligible risk of false positives.
+         * <p>
+         * This must be used when the search is purely informative (e.g. userinfo command).
+         */
+        SENSITIVE,
+        
+        /**
+         * Tries to search from all the normal ways (mention, id, tag and full username),
+         * with a small risk of false positives.
+         * <p>
+         * This must be used when the search is not critical (e.g. mute command).
+         */
+        NORMAL,
+
+        /**
+         * Tries to search only from the safe ways (mention, id and tag),
+         * with almost no risk of false positives.
+         * <p>
+         * This must be used when the search is critical (e.g. ban command).
+         */
+        SAFE
+    }
+
+    public static Optional<User> searchUserByMention(JDA jda, String message) {
+        Pattern pattern = Message.MentionType.USER.getPattern();
+        Matcher matcher = pattern.matcher(message);
+
+        if (matcher.matches()) {
+            try {
+                User user = jda.getUserById(matcher.group(1));
+                return Optional.ofNullable(user);
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static Optional<User> searchUserById(JDA jda, String id) {
+        try {
+            return Optional.ofNullable(jda.getUserById(id));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<User> searchUserByTag(JDA jda, String tag) {
+        try {
+            return Optional.ofNullable(jda.getUserByTag(tag));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<User> searchUserByName(JDA jda, String name) {
+        List<User> users = jda.getUsersByName(name, true);
+
+        if (users.size() != 1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(users.get(0));
+    }
+
+    public static Optional<User> searchUserByPartialName(JDA jda, String name) {
+        List<User> users = jda.getUsers().stream()
+                .filter(user -> user.getName().startsWith(name))
+                .collect(Collectors.toList());
+        
+        if (users.size() != 1) {
+            return Optional.empty();
+        }
+        
+        return Optional.of(users.get(0));
+    }
+    
+    public static Optional<User> searchUser(JDA jda, String message) {
+        return searchUser(jda, message, SearchMode.NORMAL);
+    }
+
+    public static Optional<User> searchUser(JDA jda, String message, SearchMode mode) {
+        Stream<Supplier<Optional<User>>> stream;
+        
+        switch (mode) {
+            case SENSITIVE:
+                stream = Stream.of(
+                        () -> searchUserByMention(jda, message),
+                        () -> searchUserById(jda, message),
+                        () -> searchUserByTag(jda, message),
+                        () -> searchUserByName(jda, message),
+                        () -> searchUserByPartialName(jda, message)
+                );
+                break;
+            case NORMAL:
+                stream = Stream.of(
+                        () -> searchUserByMention(jda, message),
+                        () -> searchUserById(jda, message),
+                        () -> searchUserByTag(jda, message),
+                        () -> searchUserByName(jda, message)
+                );
+                break;
+            case SAFE:
+                stream = Stream.of(
+                        () -> searchUserByMention(jda, message),
+                        () -> searchUserById(jda, message),
+                        () -> searchUserByTag(jda, message)
+                );
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        return stream.map(Supplier::get)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+
+    public static Optional<Member> searchMemberByMention(Guild guild, String message) {
+        Pattern pattern = Message.MentionType.USER.getPattern();
+        Matcher matcher = pattern.matcher(message);
+
+        if (matcher.matches()) {
+            try {
+                Member member = guild.getMemberById(matcher.group(1));
+                return Optional.ofNullable(member);
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static Optional<Member> searchMemberById(Guild guild, String id) {
+        try {
+            return Optional.ofNullable(guild.getMemberById(id));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<Member> searchMemberByTag(Guild guild, String tag) {
+        try {
+            return Optional.ofNullable(guild.getMemberByTag(tag));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static Optional<Member> searchMemberByName(Guild guild, String name) {
+        List<Member> members = guild.getMembersByEffectiveName(name, true);
+
+        if (members.size() != 1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(members.get(0));
+    }
+
+    public static Optional<Member> searchMemberByPartialName(Guild guild, String name) {
+        List<Member> members = guild.getMembers().stream()
+                .filter(member -> member.getEffectiveName().toLowerCase().startsWith(name.toLowerCase()))
+                .collect(Collectors.toList());
+
+        if (members.size() != 1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(members.get(0));
+    }
+
+    public static Optional<Member> searchMember(Guild guild, String message) {
+        return searchMember(guild, message, SearchMode.NORMAL);
+    }
+    
+    public static Optional<Member> searchMember(Guild guild, String message, SearchMode mode) {
+        Stream<Supplier<Optional<Member>>> stream;
+        
+        switch (mode) {
+            case SENSITIVE:
+                stream = Stream.of(
+                        () -> searchMemberByMention(guild, message),
+                        () -> searchMemberById(guild, message),
+                        () -> searchMemberByTag(guild, message),
+                        () -> searchMemberByName(guild, message),
+                        () -> searchMemberByPartialName(guild, message)
+                );
+                break;
+            case NORMAL:
+                stream = Stream.of(
+                        () -> searchMemberByMention(guild, message),
+                        () -> searchMemberById(guild, message),
+                        () -> searchMemberByTag(guild, message),
+                        () -> searchMemberByName(guild, message)
+                );
+                break;
+            case SAFE:
+                stream = Stream.of(
+                        () -> searchMemberByMention(guild, message),
+                        () -> searchMemberById(guild, message),
+                        () -> searchMemberByTag(guild, message)
+                );
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        return stream.map(Supplier::get)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+    
+    public static void sendUserNotFound(MessageChannel channel) {
+        MessageEmbed embed = Utils.buildEmbed(
+                Color.RED,
+                "Erreur : Impossible de trouver un utilisateur correspondant à l'argument donné, " +
+                        "merci d'entrer un utilisateur correct."
+        );
+
+        channel.sendMessage(embed).queue();
+    }
+    
+}

--- a/src/main/java/fr/gravendev/multibot/utils/UserSearchUtils.java
+++ b/src/main/java/fr/gravendev/multibot/utils/UserSearchUtils.java
@@ -51,7 +51,8 @@ public class UserSearchUtils {
 
         if (matcher.matches()) {
             try {
-                User user = jda.getUserById(matcher.group(1));
+                // TODO: Avoid completing and let the user decide
+                User user = jda.retrieveUserById(matcher.group(1)).complete();
                 return Optional.ofNullable(user);
             } catch (NumberFormatException e) {
                 return Optional.empty();
@@ -63,7 +64,8 @@ public class UserSearchUtils {
 
     public static Optional<User> searchUserById(JDA jda, String id) {
         try {
-            return Optional.ofNullable(jda.getUserById(id));
+            // TODO: Avoid completing and let the user decide
+            return Optional.ofNullable(jda.retrieveUserById(id).complete());
         } catch (NumberFormatException e) {
             return Optional.empty();
         }


### PR DESCRIPTION
This adds a new utility class `UserSearchUtils` to make user searching easier. Now you can search for any User or Member using the `UserSearchUtils#searchUser(JDA, String)` and the `UserSearchUtils#searchMember(JDA, String)` methods.

The searching goes through multiple processes, which can be controlled by adding a `SearchMode` argument to the search method.

There are three `SearchMode`s:
* `SENSITIVE` (search from all the possible ways, to use for info commands)
* `NORMAL` [default] (search from all the normal ways, to use for non-critical commands)
* `SAFE` (search only from the safe ways, to use for critical commands)

This new utility method is now used for all commands but the &unban command, since we currently cannot search for id.

TODO:
* Allow to search for id, without having to retrieve the whole user